### PR TITLE
Fixed Bitnami Image repo Migration and v2 ctp.

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -5,7 +5,7 @@ includes:
 
 vars:
   GITOPS_STATE_FOLDER: "state"
-  UP_VERSION: "v0.40.0"
+  UP_VERSION: "v0.42.0"
   UP_CHANNEL: "stable"
   UP_OUTPUT_DIR: "_output"
   UP_BINARY: "{{.UP_OUTPUT_DIR}}/up"

--- a/state/Taskfile.yaml
+++ b/state/Taskfile.yaml
@@ -37,7 +37,7 @@ tasks:
     deps:
       - task: up-ctx-group
     cmds:
-      - up ctp get {{.ROOT_CTP_NAME}} || up ctp create {{.ROOT_CTP_NAME}} --crossplane-channel="Rapid"
+      - up ctp get {{.ROOT_CTP_NAME}} || up ctp create {{.ROOT_CTP_NAME}} --crossplane-channel="None" --crossplane-version="2.0.2-up.5"
       - |
           until [ "$(kubectl get ctp {{.ROOT_CTP_NAME}} -ojsonpath='{.status.message}')" == "Available" ]; do
             echo "Waiting for CTP {{.ROOT_CTP_NAME}} to be ready..."
@@ -56,7 +56,7 @@ tasks:
             CONFIGS=$(yq e 'select(.kind == "Configuration") | .metadata.name' "$CONFIGS_FILE" | tr '\n' ' ')
             kubectl wait configuration.pkg --all --for=condition=Healthy --timeout 10m
             kubectl wait configuration.pkg --all --for=condition=Installed --timeout 10m
-            kubectl wait configurationrevisions.pkg --all --for=condition=Healthy --timeout 10m
+            kubectl wait configurationrevisions.pkg --all --for=condition=RevisionHealthy --timeout 10m
             kubectl wait provider.pkg --all --for condition=Healthy --timeout 10m
             kubectl -n crossplane-system wait --for=condition=Available deployment --all --timeout=5m
             kubectl wait xrd --all --for condition=Established

--- a/state/solution-idp-non-prod/configurations.yaml
+++ b/state/solution-idp-non-prod/configurations.yaml
@@ -3,7 +3,7 @@ kind: Configuration
 metadata:
   name: platform-ref-upbound
 spec:
-  package: xpkg.upbound.io/upbound/platform-ref-upbound:v0.5.0
+  package: xpkg.upbound.io/upbound/platform-ref-upbound:v0.7.0
 ---
 apiVersion: pkg.upbound.io/v1alpha1
 kind: Controller

--- a/state/solution-idp-non-prod/frontend/00-configurations/configuration.yaml
+++ b/state/solution-idp-non-prod/frontend/00-configurations/configuration.yaml
@@ -3,4 +3,4 @@ kind: Configuration
 metadata:
   name: upbound-configuration-backstage
 spec:
-  package: xpkg.upbound.io/upbound/configuration-backstage:v0.4.0
+  package: xpkg.upbound.io/upbound/configuration-backstage:v0.6.0

--- a/state/solution-idp-non-prod/frontend/20-xrs/backstage.yaml
+++ b/state/solution-idp-non-prod/frontend/20-xrs/backstage.yaml
@@ -121,7 +121,7 @@ spec:
           authenticationMode: API
         iam:
           principalArn: arn:aws:iam::609897127049:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_AdministratorAccess_d703c73ed340fde7
-        version: "1.29"
+        version: "1.31"
         nodes:
           count: 1
           instanceType: "m4.2xlarge"


### PR DESCRIPTION
### Description of your changes

Fixes #
- Bumped up the version for _platform-ref-upbound_ and _configuration-backstage_
- Fixed the taskfile for _kubectl wait_ cmd.
- bumped up the eks engine version provisioned during the process.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Tested locally and bootstrapped in upbound org. 
